### PR TITLE
No need for brackets with @Export functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Exported function must be marked with `@Export(...)` where `...` is an option ex
 codeExample1 = '
 import std.stdio: writeln;
 //This function returns void
-@Export() auto helloWorld()
+@Export auto helloWorld()
 {
     writeln("Hello World!");
     return;
@@ -100,7 +100,7 @@ Simple example with scalar inputs and outputs
 
 ```r
 codeExample3 = '
-@Export() int signD(int x)
+@Export int signD(int x)
 {
     if(x > 0)
     {
@@ -124,7 +124,7 @@ Vector input scalar output:
 
 ```r
 codeExample4 = '
-@Export() double sumD(NumericVector x)
+@Export double sumD(NumericVector x)
 {
     auto n = x.length;
     double result = 0;
@@ -144,7 +144,7 @@ Vector input with a vector output
 ```r
 codeExample5 = '
 import std.math: sqrt, pow;
-@Export() auto pdistD(double x, NumericVector y)
+@Export auto pdistD(double x, NumericVector y)
 {
     auto n = y.length;
     auto result = NumericVector(n);

--- a/inst/sauced/saucer.d
+++ b/inst/sauced/saucer.d
@@ -56,13 +56,6 @@ auto endEmbedR(int fatal)
 /*
   This is uda that marks a function to be exported 
   to R
-
-  TODO:
-  1. Rename to Export
-  2. Add functionality so that the uda name can be exported to R
-  
-  3. Further work needs to be done on this to ensure 
-  that it available at compile time
 */
 struct Export
 {

--- a/inst/sauced/translator.d
+++ b/inst/sauced/translator.d
@@ -77,7 +77,7 @@ string[] getExportedFunctions(string moduleName)()
                 static foreach(attr; __traits(getAttributes, mixin(item)))
                 {{
                     //Filters for the export attribute
-                    static if(is(typeof(attr) == Export))
+                    static if(is(typeof(attr) == Export) || is(attr == Export))
                     {
                         result ~= item;
                     }
@@ -102,12 +102,18 @@ auto getSignature(string moduleName, string item)()
     //Import the function name
     mixin(format(`import %1$s: %2$s;`, moduleName, item));
     //Filters if the attribute is Export
-    mixin(format(`enum attr = getUDAs!(%1$s, Export)[0];`, item));
+    mixin(format(`alias attr = getUDAs!(%1$s, Export)[0];`, item));
     
-    static if(attr.function_name == "")
+    static if(is(attr == Export))
     {
         enum rName = item;
-    }else{
+    }
+    else static if(attr.function_name == "")
+    {
+        enum rName = item;
+    }
+    else
+    {
         enum rName = attr.function_name;
     }
     


### PR DESCRIPTION
Exports can now be done without the brackets  @Export(), it can now be done with @Export before the function name