### PR TITLE
Added DataFrame.rows[i..j] selection semantics

### DIFF
--- a/inst/sauced/imports/list.d
+++ b/inst/sauced/imports/list.d
@@ -344,12 +344,11 @@ struct List
         boundsCheck(i, this.length);
         return VECTOR_ELT(this.sexp, cast(int)i);
     }
-    auto opIndex(string name) @trusted
+    SEXP opIndex(string name) @trusted
     {
         auto i = this.nameIndex[name];
         boundsCheck(i, this.length);
-        auto result = VECTOR_ELT(this.sexp, cast(int)i);
-        return result;
+        return VECTOR_ELT(this.sexp, cast(int)i);
     }
     /*
         Gets the names

--- a/inst/sauced/translator.d
+++ b/inst/sauced/translator.d
@@ -289,7 +289,7 @@ mixin template CreateMethodCallDemo()
 }
 
 
-template MapReduce(alias arr, alias MapFun, alias ReduceFun)
+private template MapReduce(alias arr, alias MapFun, alias ReduceFun)
 {
     alias A = typeof(arr);
     static if(is(A: E[], E))


### PR DESCRIPTION
Added DataFrame.rows[i..j] selection semantics to the DataFrame object as in issue #7 and moved several items into private so that they are protected from library users. Also added a function `slice(SEXP, I i, I j) if(isIntegral!(I))` for getting slices from SEXP RVectors.