### PR TITLE
Added support for ExternalPtr (XPtr)  (Issue #30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,11 @@ calcRandomAverage(100L)
 [Examples for R environment interop with D](./vignettes/environments.md)
 
 
+### XPtr (ExternalPtr) examples
+
+[Examples for R externalptr interop with D](./vignettes/xptr.md)
+
+
 More examples will follow ...
 
 ## Limitations
@@ -326,5 +331,4 @@ More examples will follow ...
 6. [Documentation for R's internal C API, Hadley Wickham](https://github.com/hadley/r-internals/tree/master).
 7. [Unprotecting by Value, R Blog, Tomas Kalibera](https://blog.r-project.org/2018/12/10/unprotecting-by-value/).
 8. [CRAN Repository Policy](https://cran.r-project.org/web/packages/policies.html).
-
 

--- a/inst/sauced/imports/environment.d
+++ b/inst/sauced/imports/environment.d
@@ -25,7 +25,7 @@ alias BaseEnv = R_BaseEnv;
 private auto assertSymbolOrString(string symbol)()
 {
     return format("enforce(isSymbol(%1$s) || Rf_isString(%1$s), " ~ 
-                "\"Type of symbol is not a SYMSXP\");", symbol);
+                "\"Type of symbol is not a SYMSXP or a string\");", symbol);
 }
 
 private auto assertFunction(string symbol)()

--- a/inst/sauced/imports/rmatrix.d
+++ b/inst/sauced/imports/rmatrix.d
@@ -13,7 +13,7 @@ alias RawMatrix = RMatrix!(RAWSXP);
 
 
 
-struct RMatrix(SEXPTYPE Type)
+struct RMatrix(alias Type)
 if(SEXPDataTypes!(Type))
 {
   SEXP sexp;

--- a/inst/sauced/imports/rvector.d
+++ b/inst/sauced/imports/rvector.d
@@ -395,7 +395,7 @@ if(isIntegral!(I))
 
 
 
-struct RVector(SEXPTYPE Type)
+struct RVector(alias Type)
 if(SEXPDataTypes!(Type))
 {
     SEXP sexp;

--- a/inst/sauced/imports/xptr.d
+++ b/inst/sauced/imports/xptr.d
@@ -1,38 +1,93 @@
+import std.traits: isCallable, isPointer, ReturnType;
+
+private extern(C) static void finalizerFunction(SEXP ptr)
+{
+    enforce(TYPEOF(ptr) == EXTPTRSXP, 
+        "Submitted non-EXTPTRSXP type to XPtr constructor");
+    auto vPtr = R_ExternalPtrAddr(ptr);
+    if(vPtr != null)
+    {
+        R_chk_free(vPtr);
+    }
+    return;
+}
+
+
+T* makePointer(T)(auto ref T value)
+if(!isPointer!(T) && !is(T: A[], A))
+{
+    auto ptr = cast(T*)R_chk_calloc(1, T.sizeof);
+    ptr[0] = value;
+    return ptr;
+}
+
+
+
+T* makePointer(T, Args...)(auto ref Args args)
+if(!isPointer!(T) && !is(T: A[], A))
+{
+    auto ptr = cast(T*)R_chk_calloc(1, T.sizeof);
+    writeln("Allocated memory in makePointer");
+    ptr[0] = T(args);
+    writeln("Assigned item to pointer in makePointer");
+    return ptr;
+}
+
+
+
 struct XPtr(T)
 {
-    import std.traits: isCallable, isPointer, ReturnType;
     private SEXP extptr;
     private bool needUnprotect = false;
 
-    this(P, S = SEXP)(P ptr, S tag = R_NilValue, SEXP prot = R_NilValue)
-    if(((isPointer!(P) && is(P: T*)) || isSEXP!(P)) && (isSEXP!(S) || is(S == string)))
+    this(P, S = SEXP)(auto ref P ptr, S tag = R_NilValue, SEXP prot = R_NilValue)
+    if((isSEXP!(S) || is(S == string)))
     {
+        writeln("Entered XPtr constructor method");
+        SEXP _tag_;
+        static if(isSEXP!S)
+        {
+            if(isString(tag))
+            {
+                _tag_ = installChar(asChar(tag));
+            }
+            else
+            {
+                _tag_ = tag;
+            }
+        }
+        else
+        {
+            _tag_ = installChar(mkChar(tag));
+        }
+
         static if(isSEXP!(P))
         {
             enforce(TYPEOF(ptr) == EXTPTRSXP, "Submitted non-EXTPTRSXP type to XPtr constructor");
             this.extptr = ptr;
         }
-        else
+        else static if(is(P: T*))
         {
-            static if(isSEXP!S)
-            {
-                if(isString(tag))
-                {
-                    this.extptr = R_MakeExternalPtr(cast(void*) ptr, installChar(asChar(tag)), prot);
-                }
-                else
-                {
-                    this.extptr = R_MakeExternalPtr(cast(void*) ptr, tag, prot);
-                }
-            }
-            else
-            {
-                this.extptr = R_MakeExternalPtr(cast(void*) ptr, installChar(mkChar(tag)), prot);
-            }
+            this.extptr = R_MakeExternalPtr(cast(void*) ptr, _tag_, prot);
             R_PreserveObject(this.extptr);
-            R_RegisterCFinalizerEx(this.extptr, &R_ClearExternalPtr, TRUE);
             needUnprotect = true;
         }
+        else static if(is(P: T[]))
+        {
+            enforce(ptr.length > 0, "Can not take the pointer for a zero length array");
+            this.extptr = R_MakeExternalPtr(cast(void*) &ptr[0], _tag_, prot);
+            R_PreserveObject(this.extptr);
+            needUnprotect = true;
+        }else{
+            auto pPtr = cast(P*)R_chk_calloc(1, P.sizeof);//allocates
+            pPtr[0] = ptr;
+            this.extptr = R_MakeExternalPtr(cast(void*) pPtr, _tag_, prot);
+            R_PreserveObject(this.extptr);
+            needUnprotect = true;
+        }
+        //R_RegisterCFinalizerEx(this.extptr, &finalizerFunction, TRUE);
+        R_RegisterCFinalizerEx(this.extptr, &R_ClearExternalPtr, TRUE);
+        
         return;
     }
     this(ref return scope XPtr original) @trusted
@@ -77,8 +132,18 @@ struct XPtr(T)
 }
 
 
-auto xptr(P: T*, T)(auto ref P object)
+auto xptr(P)(auto ref P object)
 if(!isSEXP!(P))
 {
-    return XPtr!(T)(object);
+    writeln("Entered xptr function constructor");
+    static if(is(P: T*, T))
+    {
+        return XPtr!(T)(object);
+    }else static if(is(P: T[], T))
+    {
+        return XPtr!(T)(object);
+    }else
+    {
+        return XPtr!(P)(object);
+    }
 }

--- a/inst/sauced/imports/xptr.d
+++ b/inst/sauced/imports/xptr.d
@@ -1,40 +1,84 @@
-//import std.stdio: writeln;
-
-private struct XPtr(T)
+struct XPtr(T)
 {
-    import std.traits: isCallable, isPointer;
-    SEXP extptr;
-    alias extptr this;
-    this(SEXP extptr)
+    import std.traits: isCallable, isPointer, ReturnType;
+    private SEXP extptr;
+    private bool needUnprotect = false;
+
+    this(P, S = SEXP)(P ptr, S tag = R_NilValue, SEXP prot = R_NilValue)
+    if(((isPointer!(P) && is(P: T*)) || isSEXP!(P)) && (isSEXP!(S) || is(S == string)))
     {
-        enforce(TYPEOF(extptr) == EXTPTRSXP, "Submitted non-EXTPTRSXP type to XPtr constructor");
-        this.extptr = extptr;
-    }
-    this(SEXP extptr, SEXP tag, SEXP prot)
-    {
-        enforce(TYPEOF(extptr) == EXTPTRSXP, "Submitted non-EXTPTRSXP type to XPtr constructor");
-        R_SetExternalPtrTag(extptr, tag);
-        R_SetExternalPtrProtected(extptr, prot);
-        this.extptr = extptr;
-    }
-    this(T object, SEXP tag = R_NilValue, SEXP prot = R_NilValue)
-    {
-        static if(isCallable!(T) || isPointer!(T))
+        static if(isSEXP!(P))
         {
-            this.extptr = R_MakeExternalPtr(cast(void*) object, tag, prot);
+            enforce(TYPEOF(ptr) == EXTPTRSXP, "Submitted non-EXTPTRSXP type to XPtr constructor");
+            this.extptr = ptr;
+        }
+        else
+        {
+            static if(isSEXP!S)
+            {
+                if(isString(tag))
+                {
+                    this.extptr = R_MakeExternalPtr(cast(void*) ptr, installChar(asChar(tag)), prot);
+                }
+                else
+                {
+                    this.extptr = R_MakeExternalPtr(cast(void*) ptr, tag, prot);
+                }
+            }
+            else
+            {
+                this.extptr = R_MakeExternalPtr(cast(void*) ptr, installChar(mkChar(tag)), prot);
+            }
+            R_PreserveObject(this.extptr);
             R_RegisterCFinalizerEx(this.extptr, &R_ClearExternalPtr, TRUE);
-        }else{
-            static assert(0, "object submitted to XPtr is not callable or a pointer.");
+            needUnprotect = true;
+        }
+        return;
+    }
+    this(ref return scope XPtr original) @trusted
+    {
+        this.extptr = original.extptr;
+    }
+    ~this()
+    {
+        if(needUnprotect)
+        {
+            R_ReleaseObject(this.extptr);
+            needUnprotect = false;
         }
     }
-    T opCast(U: T)()
+    
+    pragma(inline, true)
+    T* opCast(V: T*)()
+    if(!isSEXP!(V))
     {
-        return cast(T)(R_ExternalPtrAddr(this.extptr));
+        return cast(T*)(R_ExternalPtrAddr(this.extptr));
+    }
+    pragma(inline, true)
+    V opCast(V)()
+    if(isSEXP!V)
+    {
+        return this.extptr;
+    }
+    auto opDispatch(string member, Args...)(auto ref Args args)
+    if(!isSEXP!(T*))
+    {
+        auto ptr = cast(T*)this;
+        enum dispatch = format("ptr.%1$s(args)", member);
+        static if(__traits(compiles, mixin(dispatch)))
+        {
+            return mixin(dispatch);
+        }
+        else
+        {
+            static assert(0, format("Call %1$s is not valid", dispatch));
+        }
     }
 }
 
-auto xptr(T)(T object)
-if(!is(T == SEXP))
+
+auto xptr(P: T*, T)(auto ref P object)
+if(!isSEXP!(P))
 {
     return XPtr!(T)(object);
 }

--- a/inst/sauced/r2d.d
+++ b/inst/sauced/r2d.d
@@ -356,9 +356,9 @@ void find_interv_vec (
     int* indx);
 
 void R_max_col (double* matrix, int* nr, int* nc, int* maxes, int* ties_meth);
-void* R_chk_calloc (size_t, size_t);
+void* R_chk_calloc (size_t, size_t) @nogc;
 void* R_chk_realloc (void*, size_t);
-void R_chk_free (void*);
+void R_chk_free (void*) @nogc;
 void call_R (char*, c_long, void**, char**, c_long*, char**, c_long, char**);
 alias Sfloat = double;
 alias Sint = int;

--- a/vignettes/xptr.md
+++ b/vignettes/xptr.md
@@ -1,0 +1,82 @@
+# Examples using XPtr (Externalptr)
+
+
+```r
+externalPtrExampleCode1 = '
+import std.stdio: writeln;
+import std.format: format;
+struct Gaussian
+{
+    private double mean;
+    private double sd;
+    
+    auto density(double[] x, int log = 0)
+    {
+        auto result = NumericVector(x.length);
+        foreach(i, element; x)
+        {
+            result[i] = dnorm4(element, mean, sd, log);
+        }
+        return result;
+    }
+    auto probability(double[] q, int lowerTail = 1, int logp = 0)
+    {
+        auto result = NumericVector(q.length);
+        foreach(i, element; q)
+        {
+            result[i] = pnorm5(element, mean, sd, lowerTail, logp);
+        }
+        return result;
+    }
+    auto quantile(double[] p, int lowerTail = 1, int logp = 0)
+    {
+        auto result = NumericVector(p.length);
+        foreach(i, element; p)
+        {
+            result[i] = qnorm5(element, mean, sd, lowerTail, logp);
+        }
+        return result;
+    }
+    auto random(int n)
+    {
+        auto result = NumericVector(n);
+        foreach(i; 0..result.length)
+        {
+            result[i] = rnorm(mean, sd);
+        }
+        return result;
+    }
+}
+
+@Export auto createGaussian(double mean, double sd)
+{
+    auto x = cast(Gaussian*)R_malloc_gc(Gaussian.sizeof);
+    x[0] = Gaussian(mean, sd);
+    return xptr(x);
+}
+
+@Export auto callRandom(XPtr!(Gaussian) distPtr, int n)
+{
+    return distPtr.random(n);
+}
+@Export auto callDensity(XPtr!(Gaussian) distPtr, double[] x)
+{
+    return distPtr.density(x);
+}
+@Export auto callProbability(XPtr!(Gaussian) distPtr, double[] x)
+{
+    return distPtr.probability(x);
+}
+@Export auto callQuantile(XPtr!(Gaussian) distPtr, double[] p)
+{
+    return distPtr.quantile(p);
+}
+'
+saucer::dfunctions(externalPtrExampleCode1)
+ptr = createGaussian(5, 2)
+par(mfrow = c(2,2))
+hist({x = callRandom(ptr, 1000L)})
+plot({d = callDensity(ptr, x)} ~ x)
+plot({p = callProbability(ptr, x)} ~ x)
+hist({q = callQuantile(ptr, p)})
+```


### PR DESCRIPTION
Added support for ExternalPtr (`XPtr`) (issue #30), with accompanying vignette and reference in readme file. Changed template parameter `SEXPTYPE` -> `alias` since there are sometimes issues with matching/recognising enum template parameters.